### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, ]  #show
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -17,6 +17,11 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+
+  def show
+    @item = Item.find(params[:id])
+  end
+
 
   # def destroy
   #   item = item.find(params[:id])

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,8 +20,11 @@ class Item < ApplicationRecord
   has_one_attached :image
   
   extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :category
+  belongs_to :prefecture
+  belongs_to :scheduled_day
   belongs_to :shipping_cost
-  
+  belongs_to :status
  
   
   def was_attached?

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
         <% @items.each do |item| %>
           <li class='list'>
             <div class='item-img-content'>
-              <%= image_tag item.image, class: "item-img" %>
+              <%= link_to image_tag(item.image, class: "item-img"), item_path(item) %>
 
               <%# 商品が売れていればsold outを表示しましょう %>
               <div class='sold-out'>
@@ -174,15 +174,8 @@
     </ul>
   </div>
 </div>
-<% if user_signed_in? %>
   <%= link_to(new_item_path, class: 'purchase-btn') do %>
     <span class='purchase-btn-text'>出品する</span>
     <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
   <% end %>
-  <% else %>
-    <%= link_to(new_user_session_path, class: 'purchase-btn') do %>
-    <span class='purchase-btn-text'>出品する</span>
-    <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
-  <% end %>
-<% end %>
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,13 +1,11 @@
 <%= render "shared/header" %>
-
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,54 +14,50 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥#{@item.price}" %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_cost.name %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? && current_user.id != @item.user_id%>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname%></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.scheduled_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -78,8 +72,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
-
   <div class="comment-box">
     <form>
       <textarea class="comment-text"></textarea>
@@ -103,7 +95,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 


### PR DESCRIPTION
# what
商品詳細表示機能の追加

# why
商品の詳細を表示する為

https://gyazo.com/e67cd66f7ea7b1664e2132322ea6f323
ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/a1c935d94061f01112f46264c8c7e9f5
ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
なし
ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
https://gyazo.com/0a21108caec9b545648794c2934397b5
ログアウト状態で、商品詳細ページへ遷移した動画